### PR TITLE
Only remove hid_generic

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -4,7 +4,7 @@ MAKE="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/bui
 CLEAN="rm -f *.*o"
 BUILT_MODULE_NAME="hid-asus-fte"
 BUILT_MODULE_LOCATION="src"
-MODULES_CONF="install hid_asus_fte /sbin/modprobe -r -i i2c_hid hid_generic hid && /sbin/modprobe -a -i hid hid_asus_fte i2c_hid"
+MODULES_CONF="install hid_asus_fte /sbin/modprobe -r -i hid_generic && /sbin/modprobe -a -i hid_asus_fte hid_generic"
 DEST_MODULE_LOCATION="/updates"
 REMAKE_INITRD=yes
 AUTOINSTALL=yes

--- a/src/hid-asus-fte.c
+++ b/src/hid-asus-fte.c
@@ -65,13 +65,14 @@ static int focaltech_raw_event(struct hid_device *hdev,
 		input_mt_slot(input, i);
 		input_mt_report_slot_state(input, toolType, down);
 
-		input_report_abs(input, ABS_MT_POSITION_X, x);
-		input_report_abs(input, ABS_MT_POSITION_Y, y);
-		input_report_abs(input, ABS_MT_TOUCH_MAJOR, touch_major);
-		input_report_abs(input, ABS_MT_PRESSURE, pressure);
 
-		if (down)
+		if (down) {
+			input_report_abs(input, ABS_MT_POSITION_X, x);
+			input_report_abs(input, ABS_MT_POSITION_Y, y);
+			input_report_abs(input, ABS_MT_TOUCH_MAJOR, touch_major);
+			input_report_abs(input, ABS_MT_PRESSURE, pressure);
 			contactNum++;
+		}
 	}
 
 	input_mt_report_pointer_emulation(input, true);


### PR DESCRIPTION
Thanks for solving this load on boot-up issue!

I just had to tweak the dkms install routine a little bit. I've tried to remove as few modules as possible - as other modules could depend on them (for example, my laptop has a touchscreen which uses 'hid_multitouch' - which depends on 'hid'). It doesn't look like any modules depend on 'hid_generic' - so it should be safe to remove. I also add it back at the end - just in case another device is using it.

I figured I would do this via a pull request so you can make sure I don't break anything on your end before committing.

But thanks again for setting up the DKMS boilerplate - it's working great!